### PR TITLE
delete: gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.DS_Store


### PR DESCRIPTION
I think this should be deleted (or at least not publicly available) - I think it's better to use `.git/info/exclude' instead.